### PR TITLE
Remove country-specific urls

### DIFF
--- a/Support/Deutsch/README.md
+++ b/Support/Deutsch/README.md
@@ -7,7 +7,7 @@
 
 ## Installation
 
-1. [PokeKeys](https://itunes.apple.com/de/app/pokekeys/id1335234519?mt=8) von Victor Pavlychko installieren
+1. [PokeKeys](https://itunes.apple.com/app/pokekeys/id1335234519?mt=8) von Victor Pavlychko installieren
 2. System-"Einstellungen" öffnen
 3. Das Menü "Allgemein" öffnen
 4. Das Menü "Tastatur" öffnen

--- a/Support/English/README.md
+++ b/Support/English/README.md
@@ -7,7 +7,7 @@
 
 ## Installation
 
-1. Install [PokeKeys](https://itunes.apple.com/de/app/pokekeys/id1335234519?mt=8) by Victor Pavlychko
+1. Install [PokeKeys](https://itunes.apple.com/app/pokekeys/id1335234519?mt=8) by Victor Pavlychko
 2. Open system "Settings"
 3. Open "General" menu
 4. Open "Keyboard" menu


### PR DESCRIPTION
The english readme had `/de`. The simplest solution seems to be to remove the country designation entirely and let the browser indicate which the user wants.